### PR TITLE
Added a new adapter for WildFly 8.x.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,7 @@
   
     <properties>
         <cargo.version>1.4.5</cargo.version>
-        <jboss.version>7.2.0.Final</jboss.version>
-        <jboss.remoting.version>3.2.17.GA</jboss.remoting.version>
+        <wildfly.version>8.2.1.Final</wildfly.version>
         <glassfish.version>3.1.2.2</glassfish.version>
         <hudsonTags>upload</hudsonTags>
     </properties>
@@ -98,6 +97,12 @@
         </dependency>
         <dependency>
             <groupId>org.codehaus.cargo</groupId>
+            <artifactId>cargo-core-container-wildfly</artifactId>
+            <version>${cargo.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.cargo</groupId>
             <artifactId>cargo-core-container-tomcat</artifactId>
             <version>${cargo.version}</version>
         </dependency>
@@ -113,16 +118,12 @@
         </dependency>
          
         <dependency>
-            <groupId>org.jboss.as</groupId>
-            <artifactId>jboss-as-controller-client</artifactId>
-            <version>${jboss.version}</version>
-        </dependency>        
-        <dependency>
-            <groupId>org.jboss.remoting3</groupId>
-            <artifactId>jboss-remoting</artifactId>
-            <version>${jboss.remoting.version}</version>
-        </dependency> 
-   
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-controller-client</artifactId>
+            <version>${wildfly.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.glassfish.main.deployment</groupId>
             <artifactId>deployment-client</artifactId>

--- a/src/main/java/hudson/plugins/deploy/wildfly/WildFly8xAdapter.java
+++ b/src/main/java/hudson/plugins/deploy/wildfly/WildFly8xAdapter.java
@@ -1,0 +1,47 @@
+package hudson.plugins.deploy.wildfly;
+
+import hudson.Extension;
+import hudson.plugins.deploy.ContainerAdapterDescriptor;
+import hudson.plugins.deploy.jboss.JBossAdapter;
+
+import org.codehaus.cargo.container.Container;
+import org.codehaus.cargo.container.jboss.JBossPropertySet;
+import org.codehaus.cargo.generic.ContainerFactory;
+import org.codehaus.cargo.generic.configuration.ConfigurationFactory;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Cargo Container Adapter for WildFly 8.x remote deployment
+ * 
+ * @author Steven Christou
+ * @author Kaz Nishimura
+ */
+public class WildFly8xAdapter extends JBossAdapter {
+
+    @Property(JBossPropertySet.JBOSS_MANAGEMENT_HTTP_PORT)
+    public final Integer managementPort;
+    
+    @DataBoundConstructor
+    public WildFly8xAdapter(String url, String password, String userName, Integer managementPort) {
+        super(url, password, userName);
+        this.managementPort = managementPort;
+    }
+
+    @Override
+    public String getContainerId() {
+        return "wildfly8x";
+    }
+
+
+    @Extension
+    public static final class DescriptorImpl extends ContainerAdapterDescriptor {
+        public String getDisplayName() {
+            return "WildFly 8.x";
+        }
+    }
+    //For testing
+    @Override
+    protected Container getContainer(ConfigurationFactory configFactory, ContainerFactory containerFactory, String id) {
+        return super.getContainer(configFactory, containerFactory, id);
+    }
+}

--- a/src/main/resources/hudson/plugins/deploy/wildfly/WildFly8xAdapter/config.jelly
+++ b/src/main/resources/hudson/plugins/deploy/wildfly/WildFly8xAdapter/config.jelly
@@ -1,0 +1,18 @@
+
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:entry title="Manager user name" field="userName">
+        <f:textbox />
+    </f:entry>
+    <f:entry title="Manager password" field="password">
+        <f:password />
+    </f:entry>
+    <f:entry title="WildFly URL" field="url">
+        <f:textbox />
+    </f:entry>
+  
+    <f:entry title="WildFly JMX Management port" field="managementPort">
+        <f:textbox/>
+    </f:entry>
+  
+</j:jelly>

--- a/src/main/resources/hudson/plugins/deploy/wildfly/WildFly8xAdapter/help-managementPort.html
+++ b/src/main/resources/hudson/plugins/deploy/wildfly/WildFly8xAdapter/help-managementPort.html
@@ -1,0 +1,3 @@
+<div>
+    JBoss' JMX Management port to connect to JBoss Deployment Manager. The default is 9990.
+</div>

--- a/src/test/java/hudson/plugins/deploy/wildfly/WildFly8xAdapterTest.java
+++ b/src/test/java/hudson/plugins/deploy/wildfly/WildFly8xAdapterTest.java
@@ -1,0 +1,73 @@
+package hudson.plugins.deploy.wildfly;
+
+import static org.junit.Assert.assertTrue;
+import hudson.FilePath;
+import hudson.model.StreamBuildListener;
+import org.codehaus.cargo.container.Container;
+import org.codehaus.cargo.container.ContainerType;
+import org.codehaus.cargo.generic.ContainerFactory;
+import org.codehaus.cargo.generic.DefaultContainerFactory;
+import org.codehaus.cargo.generic.configuration.ConfigurationFactory;
+import org.codehaus.cargo.generic.configuration.DefaultConfigurationFactory;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * @author christ66
+ */
+public class WildFly8xAdapterTest {
+
+    private WildFly8xAdapter adapter;
+    private static final String home = "http://localhost:8080";
+    private static final String username = "sa";
+    private static final String password = "super";
+    private static int managementPort = 9990;
+
+    @Before
+    public void setup() {
+        adapter = new WildFly8xAdapter(home, password, username, managementPort);
+    }
+
+    @Test
+    public void testContainerId() {
+        Assert.assertEquals(adapter.getContainerId(), "wildfly8x");
+    }
+
+    @Test
+    public void testConfigure() {
+        Assert.assertEquals(adapter.userName, username);
+        Assert.assertEquals(adapter.getPassword(), password);
+
+        ConfigurationFactory configFactory = new DefaultConfigurationFactory();
+        ContainerFactory containerFactory = new DefaultContainerFactory();
+
+        Container container = adapter.getContainer(configFactory, containerFactory, adapter.getContainerId());
+        Assert.assertNotNull(container);
+        
+        Assert.assertEquals("Not a wildfly8x id.", "wildfly8x", container.getId());
+        Assert.assertEquals("Invalid container type.", ContainerType.REMOTE, container.getType());
+    }
+    
+    /**
+     * Testing notes:
+     * In order for this test to pass successfully, you first must have a .war file to deploy. The default location is: "C:\\Users\\Steven\\Downloads\\hudson-3.0.0-M1.war".
+     * The next step is to download JBoss as 7.0.0.Final version "Lightning" (http://www.jboss.org/jbossas/downloads/). Once extracted, then run the standalone.bat located
+     * in the bin folder. By default the username is sa, password is super. Default RMI port is 9999, and default URL is http://localhost:8080
+     * 
+     * This test will fail if:
+     * 1. Can't connect to http://localhost:8080 (Server does not start).
+     * 2. File does not exist.
+     * 3. Invalid user/password combo.
+     * 
+     */
+	//@Test (timeout=300000) // 5 Minute Timeout
+    public void testDeploy() throws IOException, InterruptedException {
+    	File f = new File("C:/Users/Steven/Downloads/hudson-3.0.0-M1.war");
+    	assertTrue("File: " + f.getAbsolutePath() + " does not exist", f.exists());
+        assertTrue(adapter.redeploy(new FilePath(f), null, null, null, new StreamBuildListener(System.out)));
+    }
+}


### PR DESCRIPTION
It does not resolve my problem yet, but it looks good for a standalone WildFly 8 server.

I have not installed WildFly 9 yet, this change just add the WildFly 8.x adapter only. It also replaces JBoss artifacts with newer WildFly ones. It might have broken for older JBoss servers but I could not test it now.
